### PR TITLE
demo project doesn't compile, bump target to ES2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "ES2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "es2020",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["ES6","ES2020","DOM"],            /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
When trying to deploy the demo project the following error occurs:

```
> ts-pdf@0.11.4 start /media/yigid/share/shoka/repos/work/ts-pdf
> npm run build && lite-server -c ls-config.json


> ts-pdf@0.11.4 build
> npm run buildts && npm run buildru && npm run copypdfjsworker


> ts-pdf@0.11.4 buildts
> tsc && npm run copypngtotsc

src/document/entities/strings/date-string.ts:63:25 - error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.

63     const result = /D:(?<Y>\d{4})(?<M>\d{2})(?<D>\d{2})(?<h>\d{2})(?<m>\d{2})(?<s>\d{2})/.exec(source);
                           ~~~

src/document/entities/strings/date-string.ts:63:36 - error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.

63     const result = /D:(?<Y>\d{4})(?<M>\d{2})(?<D>\d{2})(?<h>\d{2})(?<m>\d{2})(?<s>\d{2})/.exec(source);
                                      ~~~

src/document/entities/strings/date-string.ts:63:47 - error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.

63     const result = /D:(?<Y>\d{4})(?<M>\d{2})(?<D>\d{2})(?<h>\d{2})(?<m>\d{2})(?<s>\d{2})/.exec(source);
                                                 ~~~

src/document/entities/strings/date-string.ts:63:58 - error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.

63     const result = /D:(?<Y>\d{4})(?<M>\d{2})(?<D>\d{2})(?<h>\d{2})(?<m>\d{2})(?<s>\d{2})/.exec(source);
                                                            ~~~

src/document/entities/strings/date-string.ts:63:69 - error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.

63     const result = /D:(?<Y>\d{4})(?<M>\d{2})(?<D>\d{2})(?<h>\d{2})(?<m>\d{2})(?<s>\d{2})/.exec(source);
                                                                       ~~~

src/document/entities/strings/date-string.ts:63:80 - error TS1503: Named capturing groups are only available when targeting 'ES2018' or later.

63     const result = /D:(?<Y>\d{4})(?<M>\d{2})(?<D>\d{2})(?<h>\d{2})(?<m>\d{2})(?<s>\d{2})/.exec(source);
                                                                                  ~~~


Found 6 errors in the same file, starting at: src/document/entities/strings/date-string.ts:63

 ELIFECYCLE  Command failed with exit code 2.
```