### PR TITLE
Do Not Export Deleted Annotations

### DIFF
--- a/src/services/document-service.ts
+++ b/src/services/document-service.ts
@@ -291,7 +291,7 @@ export class DocumentService {
     const annotationMap = await this.getSupportedAnnotationMapAsync(); 
     annotationMap.forEach((v, k) => {
       v.forEach(x => {
-        if (!addedOnly || x.added) {
+        if ( (!addedOnly || x.added) && !x.deleted) {
           result.push(x.toDto());
         }
       });


### PR DESCRIPTION
This push changes one line of document-service's serializeAnnotationsAsync function. Previously this function only checked if the Annotation was recently added if necessary. This means that as published, all annotations are exported, even deleted ones, with no way to tell from the exported content what was deleted. 

The line change makes it also check if the AnnotationDict's deleted field is set to false as well before exporting it.